### PR TITLE
Fixing test flakiness

### DIFF
--- a/coax/experience_replay/_prioritized_test.py
+++ b/coax/experience_replay/_prioritized_test.py
@@ -134,7 +134,7 @@ def test_update():
     u = t.idx[t.idx >= 50]
     diff = 2 * (new_values[u] - old_values[u]) / (new_values[u] + old_values[u])
     print(onp.abs(diff))
-    assert onp.min(onp.abs(diff)) > 1e-3
+    assert onp.min(onp.abs(diff)) > 1e-4
 
     # neither replaced by buffer.add() nor updated by buffer.update()
     n = ~onp.isin(onp.arange(100), t.idx) & (onp.arange(100) >= 50)


### PR DESCRIPTION
The test `test_update` sometimes fails with the `assert (onp.min(onp.abs(diff)) > 0.001)` assertion failing. 

To find a solution, I collected several samples of `onp.min(onp.abs(diff))` from several test executions and computed the tail distribution. I computed the extreme percentiles to check how low can the values be:

```
0.9999::0.0008459 ~(1e-4)
0.99::0.000973 ~(1e-4)
0.9::0.00259 ~(1e-3)
```

So, it seems using `1e-4` might be better to reduce the chances of the test failing.  I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.




